### PR TITLE
Remove "Test This from Child Component" and "Test This From Parent Co…

### DIFF
--- a/grocerfinder_root/vueapps/grocerfinder/src/components/ModelListView.vue
+++ b/grocerfinder_root/vueapps/grocerfinder/src/components/ModelListView.vue
@@ -61,9 +61,6 @@
     <button @click="doFetchMore" class="btn btn-primary">
       Load More
     </button>
-    <button @click="testThis" class="btn btn-danger">
-      Test This from Child Component
-    </button>
   </div>
 </template>
 
@@ -165,9 +162,6 @@ export default {
           this.errorMessage.push(...e)
         }
       }
-    },
-    async testThis () {
-      console.log(this)
     }
   },
   computed: {

--- a/grocerfinder_root/vueapps/grocerfinder/src/views/ItemListView.vue
+++ b/grocerfinder_root/vueapps/grocerfinder/src/views/ItemListView.vue
@@ -7,9 +7,6 @@
       :doModelFetchMore="doModelFetchMore"
     >
     </model-list-view>
-    <button @click="testThis" class="btn btn-danger">
-      Test This from Parent Component
-    </button>
   </div>
 </template>
 
@@ -30,11 +27,6 @@ export default {
   },
   components: {
     ModelListView
-  },
-  methods: {
-    testThis () {
-      console.log(this)
-    }
   },
   computed: {},
   setup () {}


### PR DESCRIPTION
…mponent" buttons

Fixes #2

Context: those buttons were created to check `this` context in parent and child components due to mysterious bug.